### PR TITLE
Swap to GCS and rename to Compute Studio Storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,35 @@
-# s3like
+# Compute Studio Storage
 
-A small package that is used by COMP to read and write model results to S3 like object storage systems. This means that this package is compatible with DigitalOcean Spaces and AWS S3, since DO Spaces uses the same API as AWS S3.
+A light-weight package that is used by [Compute Studio](https://compute.studio) to read and write model results to Google Cloud Storage.
 
-Setup:
--------------------
+## Setup
 
 ```bash
-pip install s3like
-export OBJ_STORAGE_ACCESS=...
-export OBJ_STORAGE_SECRET=...
-export OBJ_STORAGE_ENDPOINT=...
-export OBJ_STORAGE_EDGE=...
-export OBJ_STORAGE_BUCKET=...
+pip install cs-storage
+export BUCKET=YOUR_BUCKET
 ```
 
-Use:
-------------
+## Authenticate
+
+```bash
+gcloud auth login
+gcloud auth application-default login
+```
+
+## Use
 
 ```python
-import s3like
+import cs_storage
 
-# run_model returns data that is compliant with the COMP outputs api.
+# run_model returns data that is compliant with the C/S outputs api.
 local_result, task_id = run_model(**kwargs)
-remote_result = s3like.write_to_s3like(task_id, local_result)
-round_trip = s3like.read_from_s3like(remote_result)
+remote_result = cs_storage.write(task_id, local_result)
+round_trip = cs_storage.read(remote_result)
 assert local_result == round_trip
 ```
 
-Test:
--------------
+## Test
+
 ```bash
 py.test -v
 ```

--- a/cs_storage/__init__.py
+++ b/cs_storage/__init__.py
@@ -11,7 +11,6 @@ try:
 except ImportError:
     GCSFS = None
 
-import requests
 from marshmallow import Schema, fields, validate
 
 
@@ -83,7 +82,7 @@ class RemoteOutputCategory(Schema):
 
 
 class RemoteResult(Schema):
-    """Serializer for load_from_S3like"""
+    """Serializer for read"""
 
     renderable = fields.Nested(RemoteOutputCategory, required=False)
     downloadable = fields.Nested(RemoteOutputCategory, required=False)
@@ -95,13 +94,13 @@ class LocalOutput(Output, Schema):
 
 
 class LocalResult(Schema):
-    """Serializer for load_to_S3like"""
+    """Serializer for read"""
 
     renderable = fields.Nested(LocalOutput, many=True)
     downloadable = fields.Nested(LocalOutput, many=True)
 
 
-def write_to_s3like(task_id, loc_result, do_upload=True):
+def write(task_id, loc_result, do_upload=True):
     if GCSFS is not None:
         gcsfs = GCSFS(BUCKET)
     else:
@@ -138,7 +137,7 @@ def write_to_s3like(task_id, loc_result, do_upload=True):
     return rem_result
 
 
-def read_from_s3like(rem_result):
+def read(rem_result):
     gcsfs = GCSFS(BUCKET)
     s = time.time()
     RemoteResult().load(rem_result)

--- a/cs_storage/tests/test_cs_storage.py
+++ b/cs_storage/tests/test_cs_storage.py
@@ -7,11 +7,11 @@ import pytest
 import requests
 from marshmallow import exceptions
 
-import s3like
+import cs_storage
 
 
 def test_JSONSerializer():
-    ser = s3like.JSONSerializer("json")
+    ser = cs_storage.JSONSerializer("json")
 
     act = ser.serialize({"hello": "world"})
     assert isinstance(act, bytes)
@@ -23,7 +23,7 @@ def test_JSONSerializer():
 
 
 def test_text_serializer():
-    ser = s3like.TextSerializer("txt")
+    ser = cs_storage.TextSerializer("txt")
 
     act = ser.serialize("hello world")
     assert isinstance(act, bytes)
@@ -35,7 +35,7 @@ def test_text_serializer():
 
 
 def test_serializer():
-    ser = s3like.Serializer("txt")
+    ser = cs_storage.Serializer("txt")
 
     act = ser.serialize(b"hello world")
     assert isinstance(act, bytes)
@@ -49,10 +49,10 @@ def test_serializer():
 def test_get_serializer():
     types = ["bokeh", "table", "CSV", "PNG", "JPEG", "MP3", "MP4", "HDF5"]
     for t in types:
-        assert s3like.get_serializer(t)
+        assert cs_storage.get_serializer(t)
 
 
-def test_s3like():
+def test_cs_storage():
     exp_loc_res = {
         "renderable": [
             {
@@ -116,16 +116,16 @@ def test_s3like():
         ],
     }
     task_id = uuid.uuid4()
-    rem_res = s3like.write_to_s3like(task_id, exp_loc_res)
-    loc_res = s3like.read_from_s3like(rem_res)
+    rem_res = cs_storage.write(task_id, exp_loc_res)
+    loc_res = cs_storage.read(rem_res)
     assert loc_res == exp_loc_res
 
-    loc_res1 = s3like.read_from_s3like({"renderable": rem_res["renderable"]})
+    loc_res1 = cs_storage.read({"renderable": rem_res["renderable"]})
     assert loc_res1["renderable"] == exp_loc_res["renderable"]
 
 
 def test_errors():
     with pytest.raises(exceptions.ValidationError):
-        s3like.write_to_s3like("123", {"bad": "data"})
+        cs_storage.write("123", {"bad": "data"})
     with pytest.raises(exceptions.ValidationError):
-        s3like.read_from_s3like({"bad": "data"})
+        cs_storage.read({"bad": "data"})

--- a/environment.yml
+++ b/environment.yml
@@ -1,0 +1,8 @@
+name: cs-storage-dev
+channels:
+  - conda-forge
+dependencies:
+  - "marshmallow>=3.0.0"
+  - pytest
+  - requests
+  - fs-gcsfs

--- a/environment.yml
+++ b/environment.yml
@@ -4,4 +4,4 @@ channels:
 dependencies:
   - "marshmallow>=3.0.0"
   - pytest
-  - fs-gcsfs
+  - gcsfs

--- a/environment.yml
+++ b/environment.yml
@@ -4,5 +4,4 @@ channels:
 dependencies:
   - "marshmallow>=3.0.0"
   - pytest
-  - requests
   - fs-gcsfs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-boto3
-marshmallow==3.0.0rc4
-requests
-pytest

--- a/setup.py
+++ b/setup.py
@@ -5,19 +5,19 @@ with open("README.md", "r") as f:
     long_description = f.read()
 
 setuptools.setup(
-    name="s3like",
+    name="cs-storage",
     version=os.environ.get("VERSION", "0.0.0"),
     author="Hank Doupe",
     author_email="henrymdoupe@gmail.com",
     description=(
-        "A small package that is used by COMP to read and write model "
-        "results to S3 like object storage systems."
+        "A small package that is used by Compute Studio to read and write model "
+        "results to google cloud storage."
     ),
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/comp-org/s3like",
+    url="https://github.com/compute-tooling/compute-studio-storage",
     packages=setuptools.find_packages(),
-    install_requires=["marshmallow>=3.*", "requests", "boto3"],
+    install_requires=["marshmallow>=3.0.0", "fs-gcsfs"],
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/compute-tooling/compute-studio-storage",
     packages=setuptools.find_packages(),
-    install_requires=["marshmallow>=3.0.0", "fs-gcsfs"],
+    install_requires=["marshmallow>=3.0.0", "gcsfs"],
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This renames the s3like project to "Compute Studio Storage" and the package name to `cs_storage`. Compute Studio now uses Google Cloud for its compute infrastructure and will continue to do so for the foreseeable future. Thus, it makes sense to migrate our file storage to Google Cloud, too.

Further, this has the advantage of being able to use [`gcsfs`](https://gcsfs.readthedocs.io/en/latest/index.html) as an interface to our cloud storage service which provides a familiar file-like API that is much easier to use than boto3.