### PR TITLE
Fix handling of PNG/JPG data

### DIFF
--- a/cs_storage/__init__.py
+++ b/cs_storage/__init__.py
@@ -24,7 +24,7 @@ class Serializer:
     def serialize(self, data):
         return data
 
-    def deserialize(self, data):
+    def deserialize(self, data, json_serializable=True):
         return data
 
 
@@ -32,7 +32,7 @@ class JSONSerializer(Serializer):
     def serialize(self, data):
         return json.dumps(data).encode()
 
-    def deserialize(self, data):
+    def deserialize(self, data, json_serializable=True):
         return json.loads(data.decode())
 
 
@@ -40,13 +40,16 @@ class TextSerializer(Serializer):
     def serialize(self, data):
         return data.encode()
 
-    def deserialize(self, data):
+    def deserialize(self, data, json_serializable=True):
         return data.decode()
 
 
 class Base64Serializer(Serializer):
-    def deserialize(self, data):
-        return base64.b64encode(data).decode("utf-8")
+    def deserialize(self, data, json_serializable=True):
+        if json_serializable:
+            return base64.b64encode(data).decode("utf-8")
+        else:
+            return data
 
     def from_string(self, data):
         return base64.b64decode(data.encode("utf-8"))
@@ -139,7 +142,7 @@ def write(task_id, loc_result, do_upload=True):
     return rem_result
 
 
-def read(rem_result):
+def read(rem_result, json_serializable=True):
     # compute studio results have public read access.
     fs = gcsfs.GCSFileSystem(token="anon")
     s = time.time()
@@ -154,7 +157,7 @@ def read(rem_result):
 
         for rem_output in rem_result[category]["outputs"]:
             ser = get_serializer(rem_output["media_type"])
-            rem_data = ser.deserialize(zipfileobj.read(rem_output["filename"]))
+            rem_data = ser.deserialize(zipfileobj.read(rem_output["filename"]), json_serializable)
             read[category].append(
                 {
                     "title": rem_output["title"],

--- a/cs_storage/__init__.py
+++ b/cs_storage/__init__.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import json
 import os
@@ -43,17 +44,25 @@ class TextSerializer(Serializer):
         return data.decode()
 
 
+class Base64Serializer(Serializer):
+    def deserialize(self, data):
+        return base64.b64encode(data).decode("utf-8")
+
+    def from_string(self, data):
+        return base64.b64decode(data.encode("utf-8"))
+
+
 def get_serializer(media_type):
     return {
         "bokeh": JSONSerializer("json"),
         "table": TextSerializer("html"),
         "CSV": TextSerializer("csv"),
-        "PNG": Serializer("png"),
-        "JPEG": Serializer("jpeg"),
-        "MP3": Serializer("mp3"),
-        "MP4": Serializer("mp4"),
-        "HDF5": Serializer("h5"),
-        "PDF": Serializer("pdf"),
+        "PNG": Base64Serializer("png"),
+        "JPEG": Base64Serializer("jpeg"),
+        "MP3": Base64Serializer("mp3"),
+        "MP4": Base64Serializer("mp4"),
+        "HDF5": Base64Serializer("h5"),
+        "PDF": Base64Serializer("pdf"),
         "Markdown": TextSerializer("md"),
         "Text": TextSerializer("txt"),
     }[media_type]

--- a/cs_storage/__init__.py
+++ b/cs_storage/__init__.py
@@ -18,6 +18,9 @@ BUCKET = os.environ.get("BUCKET", None)
 
 
 class Serializer:
+    """
+    Base class for serializng input data to bytes and back.
+    """
     def __init__(self, ext):
         self.ext = ext
 

--- a/cs_storage/tests/test_cs_storage.py
+++ b/cs_storage/tests/test_cs_storage.py
@@ -1,3 +1,4 @@
+import base64
 import io
 import json
 import uuid
@@ -8,6 +9,44 @@ import requests
 from marshmallow import exceptions
 
 import cs_storage
+
+
+@pytest.fixture
+def png():
+    import matplotlib.pyplot as plt
+    import numpy as np
+    x = np.linspace(0, 2, 100)
+    plt.figure()
+    plt.plot(x, x, label='linear')
+    plt.plot(x, x**2, label='quadratic')
+    plt.plot(x, x**3, label='cubic')
+    plt.xlabel('x label')
+    plt.ylabel('y label')
+    plt.title("Simple Plot")
+    plt.legend()
+    initial_buff = io.BytesIO()
+    plt.savefig(initial_buff, format="png")
+    initial_buff.seek(0)
+    return initial_buff.read()
+
+
+@pytest.fixture
+def jpg():
+    import matplotlib.pyplot as plt
+    import numpy as np
+    x = np.linspace(0, 2, 100)
+    plt.figure()
+    plt.plot(x, x, label='linear')
+    plt.plot(x, x**2, label='quadratic')
+    plt.plot(x, x**3, label='cubic')
+    plt.xlabel('x label')
+    plt.ylabel('y label')
+    plt.title("Simple Plot")
+    plt.legend()
+    initial_buff = io.BytesIO()
+    plt.savefig(initial_buff, format="jpg")
+    initial_buff.seek(0)
+    return initial_buff.read()
 
 
 def test_JSONSerializer():
@@ -44,6 +83,21 @@ def test_serializer():
     act = ser.deserialize(b"hello world")
     assert isinstance(act, bytes)
     assert act == b"hello world"
+
+
+def test_base64serializer(png, jpg):
+    """Test round trip serializtion/deserialization of PNG and JPG"""
+    ser = cs_storage.Base64Serializer("PNG")
+    asbytes = ser.serialize(png)
+    asstr = ser.deserialize(asbytes)
+    assert png == ser.from_string(asstr)
+    assert json.dumps({"pic": asstr})
+
+    ser = cs_storage.Base64Serializer("JPG")
+    asbytes = ser.serialize(jpg)
+    asstr = ser.deserialize(asbytes)
+    assert jpg == ser.from_string(asstr)
+    assert json.dumps({"pic": asstr})
 
 
 def test_get_serializer():

--- a/cs_storage/tests/test_cs_storage.py
+++ b/cs_storage/tests/test_cs_storage.py
@@ -106,7 +106,7 @@ def test_get_serializer():
         assert cs_storage.get_serializer(t)
 
 
-def test_cs_storage():
+def test_cs_storage(png, jpg):
     exp_loc_res = {
         "renderable": [
             {
@@ -122,12 +122,12 @@ def test_cs_storage():
             {
                 "media_type": "PNG",
                 "title": "PNG data",
-                "data": b"PNG bytes",
+                "data": png,
             },
             {
                 "media_type": "JPEG",
                 "title": "JPEG data",
-                "data": b"JPEG bytes",
+                "data": jpg,
             },
             {
                 "media_type": "MP3",
@@ -171,11 +171,17 @@ def test_cs_storage():
     }
     task_id = uuid.uuid4()
     rem_res = cs_storage.write(task_id, exp_loc_res)
-    loc_res = cs_storage.read(rem_res)
+    loc_res = cs_storage.read(rem_res, json_serializable=False)
     assert loc_res == exp_loc_res
+    assert json.dumps(
+        cs_storage.read(rem_res, json_serializable=True)
+    )
 
-    loc_res1 = cs_storage.read({"renderable": rem_res["renderable"]})
+    loc_res1 = cs_storage.read({"renderable": rem_res["renderable"]}, json_serializable=False)
     assert loc_res1["renderable"] == exp_loc_res["renderable"]
+    assert json.dumps(
+        cs_storage.read({"renderable": rem_res["renderable"]}, json_serializable=True)
+    )
 
 
 def test_errors():

--- a/environment.yml
+++ b/environment.yml
@@ -5,3 +5,5 @@ dependencies:
   - "marshmallow>=3.0.0"
   - pytest
   - gcsfs
+  - matplotlib
+  - numpy


### PR DESCRIPTION
This PR fixes the handling of PNG, JPG, and other binary data like MP4. A `bytes` object should be passed to the `serialize` method for `Base64Serializer` and that will be written directly to the file where it will be stored. The `deserialize` method for `Base64Serializer` turns that data into a string that can be passed in a JSON object. This is useful for pulling these PNG or JPG files from cloud storage and serving them over a REST API.

The encoding for turning this data into a JSON serializable uses Base64 and UTF-8 encodings. 

- bytes object to string --> `base64.b64encode(data).decode("utf-8")`
- string back to bytes object --> `base64.b64decode(data.encode("utf-8"))`

The data can round tripped like this:

```python
ser = cs_storage.Base64Serializer("PNG")

# convert png_data to a string
as_str = base64.b64encode(png_data).decode("utf-8")  # or ser.deserialize(png_data)

# convert string back to original bytes data
as_bytes = base64.b64decode(as_str.encode("utf-8"))  # or ser.from_string(as_str)

# check equal
assert png_data == as_bytes

```
