### PR TITLE
Turn off flags that deal with threading/multiprocessing

### DIFF
--- a/cs_storage/screenshot.py
+++ b/cs_storage/screenshot.py
@@ -67,7 +67,12 @@ async def _screenshot(template_path, pic_path):
     puppeteer should be used for creating these screenshots. The
     downside of using puppeteer is that it is written in nodejs.
     """
-    browser = await launch(args=["--no-sandbox"])
+    browser = await launch(
+        handleSIGINT=False,
+        handleSIGTERM=False,
+        handleSIGHUP=False,
+        args=["--no-sandbox"],
+    )
     page = await browser.newPage()
     await page.goto(f"file://{template_path}")
     await page.setViewport(dict(width=1920, height=1080))


### PR DESCRIPTION
This PR resolves the bug that caused the error on [PSLmodels/OG-USA#19](https://compute.studio/PSLmodels/OG-USA/19/):

```
Traceback (most recent call last):
  File "/home/distributed/cs-dask-sim/cs_dask_sim.py", line 40, in done_callback
    outputs = cs_storage.write(job_id, outputs)
  File "/opt/conda/lib/python3.7/site-packages/cs_storage/__init__.py", line 181, in write
    write_pic(fs, output)
  File "/opt/conda/lib/python3.7/site-packages/cs_storage/__init__.py", line 136, in write_pic
    pic_data = screenshot(output)
  File "/opt/conda/lib/python3.7/site-packages/cs_storage/screenshot.py", line 108, in screenshot
    _screenshot(template_path, pic_path)
  File "/opt/conda/lib/python3.7/asyncio/base_events.py", line 579, in run_until_complete
    return future.result()
  File "/opt/conda/lib/python3.7/site-packages/cs_storage/screenshot.py", line 70, in _screenshot
    browser = await launch(args=["--no-sandbox"])
  File "/opt/conda/lib/python3.7/site-packages/pyppeteer/launcher.py", line 311, in launch
    return await Launcher(options, **kwargs).launch()
  File "/opt/conda/lib/python3.7/site-packages/pyppeteer/launcher.py", line 180, in launch
    signal.signal(signal.SIGINT, _close_process)
  File "/opt/conda/lib/python3.7/signal.py", line 47, in signal
    handler = _signal.signal(_enum_to_int(signalnum), _enum_to_int(handler))
ValueError: signal only works in main thread
```

For some reason, Pyppeteer cannot be run when it is not the main thread. I found the fix on this [stack over flow](https://stackoverflow.com/questions/53679905/running-pypupeteer-in-flask-gives-valueerror-signal-only-works-in-main-thread) post, and I was able to re-create and resolve the bug locally.