### PR TITLE
Data needs to be serialized to text before it is screenshotted

### DIFF
--- a/cs_storage/__init__.py
+++ b/cs_storage/__init__.py
@@ -178,7 +178,14 @@ def write(task_id, loc_result, do_upload=True):
                 }
             )
             if do_upload and category == "renderable":
-                write_pic(fs, output)
+                # This data will be rendered on an HTML template and needs
+                # to be deserialized from bytes to text.
+                write_pic(
+                    fs,
+                    dict(
+                        output, data=serializer.deserialize(ser, json_serializable=True)
+                    ),
+                )
         zipfileobj.close()
         buff.seek(0)
         if do_upload:

--- a/cs_storage/tests/test-ogusa-remote.json
+++ b/cs_storage/tests/test-ogusa-remote.json
@@ -1,0 +1,33 @@
+{
+    "outputs": {
+        "renderable": {
+            "outputs": [
+                {
+                    "id": "2ba84d72-4a70-429b-8167-00d050658615",
+                    "title": "Percentage Changes in Consumption by Lifetime Income Percentile Group",
+                    "filename": "Percentage Changes in Consumption by Lifetime Income Percentile Group.png",
+                    "media_type": "PNG"
+                },
+                {
+                    "id": "9513e496-357d-4ee8-b6ad-a98d0e37e118",
+                    "title": "Percentage Changes in Economic Aggregates Between Baseline and Reform Policy",
+                    "filename": "Percentage Changes in Economic Aggregates Between Baseline and Reform Policy.html",
+                    "media_type": "table"
+                }
+            ],
+            "ziplocation": "91d6b58b-a2f6-4faf-92e9-b51f2cd08525_renderable.zip"
+        },
+        "downloadable": {
+            "outputs": [
+                {
+                    "id": "033c82f4-f8b7-4d5a-8313-4f9516fb672d",
+                    "title": "Percentage Changes in Economic Aggregates Between Baseline and Reform Policy",
+                    "filename": "Percentage Changes in Economic Aggregates Between Baseline and Reform Policy.csv",
+                    "media_type": "CSV"
+                }
+            ],
+            "ziplocation": "91d6b58b-a2f6-4faf-92e9-b51f2cd08525_downloadable.zip"
+        }
+    },
+    "version": "v1"
+}

--- a/cs_storage/tests/test_cs_storage.py
+++ b/cs_storage/tests/test_cs_storage.py
@@ -51,6 +51,31 @@ def jpg():
     return initial_buff.read()
 
 
+@pytest.fixture
+def bokeh_plot():
+    try:
+        from bokeh.plotting import figure
+        from bokeh.embed import json_item
+    except ImportError:
+        import warnings
+
+        warnings.warn("Bokeh is not installed.")
+    # see: https://bokeh.pydata.org/en/latest/docs/user_guide/quickstart.html#getting-started
+
+    # prepare some data
+    x = [1, 2, 3, 4, 5]
+    y = [6, 7, 2, 4, 5]
+
+    # create a new plot with a title and axis labels
+    p = figure(title="simple line example", x_axis_label="x", y_axis_label="y")
+
+    # add a line renderer with legend and line thickness
+    p.line(x, y, legend="Temp.", line_width=2)
+
+    # get the results
+    return json_item(p)
+
+
 def test_JSONSerializer():
     ser = cs_storage.JSONSerializer("json")
 
@@ -108,15 +133,11 @@ def test_get_serializer():
         assert cs_storage.get_serializer(t)
 
 
-def test_cs_storage(png, jpg):
+def test_cs_storage(png, jpg, bokeh_plot):
     dummy_uuid = "c7a65ad2-0c2c-45d7-b0f7-d9fd524c49b3"
     exp_loc_res = {
         "renderable": [
-            {
-                "media_type": "bokeh",
-                "title": "bokeh plot",
-                "data": {"html": "<div/>", "javascript": "console.log('hello world')"},
-            },
+            {"media_type": "bokeh", "title": "bokeh plot", "data": bokeh_plot,},
             {"media_type": "table", "title": "table stuff", "data": "<table/>"},
             {"media_type": "PNG", "title": "PNG data", "data": png},
             {"media_type": "JPEG", "title": "JPEG data", "data": jpg},

--- a/cs_storage/tests/test_screenshot.py
+++ b/cs_storage/tests/test_screenshot.py
@@ -39,7 +39,7 @@ def test_use_with_dask():
 
         warnings.warn("Dask and/or Distributed are not installed")
         return
-    with open(f"{CURRENT_DIR}/test-tb-remote.json") as f:
+    with open(f"{CURRENT_DIR}/test-ogusa-remote.json") as f:
         remote_outputs = json.loads(f.read())
     outputs = cs_storage.read(remote_outputs["outputs"])
 


### PR DESCRIPTION
This resolves a bug where screenshots of picture outputs look like this:

![Screenshot from 2020-01-29 13-26-00](https://user-images.githubusercontent.com/9206065/73385281-e9046e80-429a-11ea-94d0-bf67c3265087.png)
