### PR TITLE
Add support for MathJax

### DIFF
--- a/cs_storage/templates/index.html
+++ b/cs_storage/templates/index.html
@@ -22,6 +22,18 @@
   <script type="text/javascript" src={{bokeh_scripts.cdn_js|safe}}></script>
   <script type="text/javascript" src={{bokeh_scripts.widget_js|safe}}></script>
 
+  <script>
+    window.MathJax = {
+      tex: {
+        inlineMath: [['$', '$'], ['\\(', '\\)']]
+      }
+    };
+  </script>
+  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+  <script type="text/javascript" id="MathJax-script" async
+    src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+    </script>
+
 </head>
 
 <body>


### PR DESCRIPTION
For context, see compute-tooling/compute-studio#280. This PR adds MathJax to the HTML files that are used to create screenshots of the outputs.