### PR TITLE
Add support for more storage object protocols

### DIFF
--- a/cs_storage/screenshot.py
+++ b/cs_storage/screenshot.py
@@ -81,7 +81,7 @@ async def _screenshot(template_path, pic_path):
         width=min(boundingbox["width"], 1920),
         height=min(boundingbox["height"], 1080),
     )
-    await page.screenshot(path=f"{pic_path}", type="png", clip=clip)
+    await page.screenshot(path=f"{pic_path}", type_="png", clip=clip)
     await browser.close()
 
 

--- a/environment.yml
+++ b/environment.yml
@@ -6,9 +6,12 @@ dependencies:
   - pytest
   - gcsfs
   - jinja2 # optional
-  - pyppeteer # optional
   - bokeh # optional
   - websockets # optional
   - matplotlib
   - numpy
   - "pillow<7"
+  - pip
+  - pip:
+      - pyppeteer2 # optional
+      # - git+https://github.com/pyppeteer/pyppeteer@pup2.1.1 # includes pyee bug fix

--- a/environment.yml
+++ b/environment.yml
@@ -13,5 +13,5 @@ dependencies:
   - "pillow<7"
   - pip
   - pip:
-      - pyppeteer2 # optional
-      # - git+https://github.com/pyppeteer/pyppeteer@pup2.1.1 # includes pyee bug fix
+      # - pyppeteer2 # optional
+      - git+https://github.com/pyppeteer/pyppeteer@pup2.1.1 # includes pyee bug fix


### PR DESCRIPTION
Initially, this project was written to work with s3 protocols and used Digital Ocean Spaces, an s3-compliant object storage backend. Eventually, C/S infrastructure was swapped from DO to GCP, and [`gcsfs`](https://gcsfs.readthedocs.io/en/latest/) replaced [`boto3`](https://boto3.amazonaws.com/v1/documentation/api/latest/index.html) for interfacing with cloud storage backends. This PR updates the project to work with s3 and gcs compliant storage backends by using [`fsspec`](https://github.com/intake/filesystem_spec) as a common interface for a wide-variety of cloud storage backends.

Some motivations/advantages:-
- Try out `fsspec` before using it more broadly as an interface for cloud storage backends throughout C/S code. 
- Makes it easier to run C/S on more cloud providers.
- Makes C/S compatible with [MinIO](https://min.io/), a kubernetes native object store. While we probably don't want to use MinIO for production, it takes C/S closer to the goal of running it locally with one command (ref: https://github.com/compute-tooling/compute-studio/issues/221).

This PR also pins cs-storage to a yet-to-be released version of pyppeteer2 that has some fixes for various warnings.