### PR TITLE
Make cloud storage files private

### DIFF
--- a/cs_storage/__init__.py
+++ b/cs_storage/__init__.py
@@ -230,8 +230,7 @@ def read(rem_result, json_serializable=True, protocol="gcs"):
     read = {"renderable": [], "downloadable": []}
     for category in rem_result:
         with fs.open(
-            f"{protocol}://{BUCKET}/{rem_result[category]['ziplocation']}",
-            "rb",
+            f"{protocol}://{BUCKET}/{rem_result[category]['ziplocation']}", "rb",
         ) as f:
             res = f.read()
 
@@ -256,9 +255,14 @@ def read(rem_result, json_serializable=True, protocol="gcs"):
     return read
 
 
+def read_screenshot(screenshot_id, protocol="gcs"):
+    if not screenshot_id.endswith(".png"):
+        screenshot_id += ".png"
+    with fs.open(f"{protocol}://{BUCKET}/{screenshot_id}", "rb") as f:
+        return f.read()
+
+
 def add_screenshot_links(rem_result):
     for rem_output in rem_result["renderable"]["outputs"]:
-        rem_output[
-            "screenshot"
-        ] = f"https://storage.googleapis.com/{BUCKET}/{rem_output['id']}.png"
+        rem_output["screenshot"] = f"{rem_output['id']}.png"
     return rem_result

--- a/cs_storage/__init__.py
+++ b/cs_storage/__init__.py
@@ -225,8 +225,6 @@ def write(task_id, loc_result, do_upload=True, protocol="gcs"):
 
 
 def read(rem_result, json_serializable=True, protocol="gcs"):
-    # compute studio results have public read access.
-    # fs = gcsfs.GCSFileSystem(token="anon")
     s = time.time()
     RemoteResult().load(rem_result)
     read = {"renderable": [], "downloadable": []}
@@ -234,7 +232,6 @@ def read(rem_result, json_serializable=True, protocol="gcs"):
         with fs.open(
             f"{protocol}://{BUCKET}/{rem_result[category]['ziplocation']}",
             "rb",
-            **{protocol: {"token": "anon"}},
         ) as f:
             res = f.read()
 

--- a/cs_storage/screenshot.py
+++ b/cs_storage/screenshot.py
@@ -15,8 +15,6 @@ except ImportError:
     Template = None
     launch = None
 
-import cs_storage
-
 
 CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 

--- a/cs_storage/tests/test_cs_storage.py
+++ b/cs_storage/tests/test_cs_storage.py
@@ -1,11 +1,8 @@
-import base64
 import io
 import json
-import uuid
-import zipfile
+import os
 
 import pytest
-import requests
 from marshmallow import exceptions
 
 import cs_storage
@@ -208,15 +205,23 @@ def test_cs_storage_serialization(exp_loc_res):
 def test_add_screenshot_links():
     rem_res = {"renderable": {"outputs": [{"id": "1234"}, {"id": "4567"}]}}
 
-    url = f"https://storage.googleapis.com/{cs_storage.BUCKET}/"
     assert cs_storage.add_screenshot_links(rem_res) == {
         "renderable": {
             "outputs": [
-                {"id": "1234", "screenshot": url + "1234.png"},
-                {"id": "4567", "screenshot": url + "4567.png"},
+                {"id": "1234", "screenshot": "1234.png"},
+                {"id": "4567", "screenshot": "4567.png"},
             ]
         }
     }
+
+    current_dir = os.path.abspath(os.path.dirname(__file__))
+    with open(f"{current_dir}/test-tc-remote.json") as f:
+        remote_outputs = json.loads(f.read())["outputs"]
+
+    cs_storage.add_screenshot_links(remote_outputs)
+    for output in remote_outputs["renderable"]["outputs"]:
+        link = output["screenshot"]
+        assert isinstance(cs_storage.read_screenshot(link), bytes)
 
 
 def test_errors():

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setuptools.setup(
     long_description_content_type="text/markdown",
     url="https://github.com/compute-tooling/compute-studio-storage",
     packages=setuptools.find_packages(),
-    install_requires=["marshmallow>=3.0.0", "gcsfs"],
+    install_requires=["marshmallow>=3.0.0", "fsspec", "gcsfs"],
     include_package_data=True,
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This PR makes cloud storage files private, meaning that the only way to interact with them is through the compute.studio webserver. This makes it possible to use the C/S auth system to control access to private files.